### PR TITLE
Add Deep Interest Network (DIN) model

### DIFF
--- a/deepctr_torch/inputs.py
+++ b/deepctr_torch/inputs.py
@@ -4,21 +4,26 @@ Author:
     Weichen Shen,wcshen1994@163.com
 """
 
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict, namedtuple, defaultdict
 from itertools import chain
 
 import torch
+import torch.nn as nn
 
 from .layers.utils import concat_fun
+from .layers.sequence import SequencePoolingLayer
+
+DEFAULT_GROUP_NAME = "default_group"
 
 
-class SparseFeat(namedtuple('SparseFeat', ['name', 'dimension', 'use_hash', 'dtype', 'embedding_name', 'embedding'])):
+class SparseFeat(namedtuple('SparseFeat', ['name', 'dimension', 'use_hash', 'dtype', 'embedding_name', 'embedding', 'group_name'])):
     __slots__ = ()
 
-    def __new__(cls, name, dimension, use_hash=False, dtype="int32", embedding_name=None, embedding=True):
+    def __new__(cls, name, dimension, use_hash=False, dtype="int32",
+                embedding_name=None, embedding=True, group_name=DEFAULT_GROUP_NAME):
         if embedding and embedding_name is None:
             embedding_name = name
-        return super(SparseFeat, cls).__new__(cls, name, dimension, use_hash, dtype, embedding_name, embedding)
+        return super(SparseFeat, cls).__new__(cls, name, dimension, use_hash, dtype, embedding_name, embedding, group_name)
 
 
 class DenseFeat(namedtuple('DenseFeat', ['name', 'dimension', 'dtype'])):
@@ -30,15 +35,15 @@ class DenseFeat(namedtuple('DenseFeat', ['name', 'dimension', 'dtype'])):
 
 class VarLenSparseFeat(namedtuple('VarLenFeat',
                                   ['name', 'dimension', 'maxlen', 'combiner', 'use_hash', 'dtype', 'embedding_name',
-                                   'embedding'])):
+                                   'embedding', 'group_name'])):
     __slots__ = ()
 
     def __new__(cls, name, dimension, maxlen, combiner="mean", use_hash=False, dtype="float32", embedding_name=None,
-                embedding=True):
+                embedding=True, group_name=DEFAULT_GROUP_NAME):
         if embedding_name is None:
             embedding_name = name
         return super(VarLenSparseFeat, cls).__new__(cls, name, dimension, maxlen, combiner, use_hash, dtype,
-                                                    embedding_name, embedding)
+                                                    embedding_name, embedding, group_name)
 
 
 def get_feature_names(feature_columns):

--- a/deepctr_torch/layers/activation.py
+++ b/deepctr_torch/layers/activation.py
@@ -56,22 +56,22 @@ class Dice(nn.Module):
         return out
 
 
-def activation_layer(activation, hidden_size=None, dice_dim=2):
+def activation_layer(act_name, hidden_size=None, dice_dim=2):
     """Construct activation layers
 
     Args:
-        activation: str, name of activation function
+        act_name: str, name of activation function
         hidden_size: int, used for Dice activation
         dice_dim: int, used for Dice activation
     Return:
         act_layer: activation layer
     """
-    if activation.lower() == 'relu':
+    if act_name.lower() == 'relu':
         act_layer = nn.ReLU(inplace=True)
-    elif activation.lower() == 'dice':
+    elif act_name.lower() == 'dice':
         assert dice_dim
         act_layer = Dice(hidden_size, dice_dim)
-    elif activation.lower() == 'prelu':
+    elif act_name.lower() == 'prelu':
         act_layer = nn.PReLU()
     else:
         raise NotImplementedError

--- a/deepctr_torch/layers/activation.py
+++ b/deepctr_torch/layers/activation.py
@@ -66,7 +66,7 @@ def activation_layer(act_name, hidden_size=None, dice_dim=2):
     Return:
         act_layer: activation layer
     """
-    if act_name.lower() == 'relu':
+    if act_name.lower() == 'relu' or 'linear':
         act_layer = nn.ReLU(inplace=True)
     elif act_name.lower() == 'dice':
         assert dice_dim

--- a/deepctr_torch/layers/activation.py
+++ b/deepctr_torch/layers/activation.py
@@ -19,37 +19,51 @@ class Dice(nn.Module):
     
     References
         - [Zhou G, Zhu X, Song C, et al. Deep interest network for click-through rate prediction[C]//Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining. ACM, 2018: 1059-1068.](https://arxiv.org/pdf/1706.06978.pdf)
+        - https://github.com/zhougr1993/DeepInterestNetwork, https://github.com/fanoping/DIN-pytorch
     """
-    def __init__(self, num_features, dim=2):
+    def __init__(self, num_features, epsilon=1e-9):
         super(Dice, self).__init__()
-        assert dim == 2 or dim == 3
-        self.bn = nn.BatchNorm1d(num_features, eps=1e-9)
+        self.bn = nn.BatchNorm1d(num_features, eps=epsilon)
         self.sigmoid = nn.Sigmoid()
-        self.dim = dim
-        
-        if self.dim == 3:
-            self.alpha = torch.zeros((num_features, 1)).to(device)
-        elif self.dim == 2:
-            self.alpha = torch.zeros((num_features,)).to(device)
-        
 
-    def forward(self, x):
-        if self.dim == 3:
-            x = torch.transpose(x, 1, 2)
-            x_p = self.sigmoid(self.bn(x))
-            out = self.alpha * (1 - x_p) * x + x_p * x
-            out = torch.transpose(out, 1, 2)
+        self.alpha = torch.zeros((num_features,)).to(device)
         
-        elif self.dim == 2:
-            x_p = self.sigmoid(self.bn(x))
-            out = self.alpha * (1 - x_p) * x + x_p * x
+    def forward(self, x):
+        assert x.dim() == 2
+        x_p = self.sigmoid(self.bn(x))
+        out = self.alpha * (1 - x_p) * x + x_p * x
         
         return out
 
 
+def activation_layer(activation, hidden_size=None, dice_dim=2):
+    """Construct activation layers
+
+    Args:
+        activation: str, name of activation function
+        hidden_size: int, used for Dice activation
+        dice_dim: int, used for Dice activation
+    Return:
+        act_layer: activation layer
+    """
+    if activation.lower() == 'relu':
+        act_layer = nn.ReLU(inplace=True)
+    elif activation.lower() == 'dice':
+        assert dice_dim
+        act_layer = Dice(hidden_size)
+    elif activation.lower() == 'prelu':
+        act_layer = nn.PReLU()
+    else:
+        raise NotImplementedError
+
+    return act_layer
+
+
 if __name__ == "__main__":
-    a = Dice(32, dim=3)
-    # b = torch.zeros((10, 32))
-    b = torch.zeros((10, 100, 32))
+    torch.manual_seed(7)
+    a = Dice(3)
+    b = torch.rand((5, 3))
     c = a(b)
     print(c.size())
+    print('b:', b)
+    print('c:', c)

--- a/deepctr_torch/layers/activation.py
+++ b/deepctr_torch/layers/activation.py
@@ -1,0 +1,55 @@
+# -*- coding:utf-8 -*-
+"""
+
+Author:
+    Yuef Zhang
+
+"""
+import sys
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
+
+class Dice(nn.Module):
+    """
+    
+    References
+        - [Zhou G, Zhu X, Song C, et al. Deep interest network for click-through rate prediction[C]//Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining. ACM, 2018: 1059-1068.](https://arxiv.org/pdf/1706.06978.pdf)
+    """
+    def __init__(self, num_features, dim=2):
+        super(Dice, self).__init__()
+        assert dim == 2 or dim == 3
+        self.bn = nn.BatchNorm1d(num_features, eps=1e-9)
+        self.sigmoid = nn.Sigmoid()
+        self.dim = dim
+        
+        if self.dim == 3:
+            self.alpha = torch.zeros((num_features, 1)).to(device)
+        elif self.dim == 2:
+            self.alpha = torch.zeros((num_features,)).to(device)
+        
+
+    def forward(self, x):
+        if self.dim == 3:
+            x = torch.transpose(x, 1, 2)
+            x_p = self.sigmoid(self.bn(x))
+            out = self.alpha * (1 - x_p) * x + x_p * x
+            out = torch.transpose(out, 1, 2)
+        
+        elif self.dim == 2:
+            x_p = self.sigmoid(self.bn(x))
+            out = self.alpha * (1 - x_p) * x + x_p * x
+        
+        return out
+
+
+if __name__ == "__main__":
+    a = Dice(32, dim=3)
+    # b = torch.zeros((10, 32))
+    b = torch.zeros((10, 100, 32))
+    c = a(b)
+    print(c.size())

--- a/deepctr_torch/layers/core.py
+++ b/deepctr_torch/layers/core.py
@@ -33,9 +33,8 @@ class DNN(nn.Module):
     """
 
     def __init__(self, inputs_dim, hidden_units, activation='relu', l2_reg=0, dropout_rate=0, use_bn=False,
-                 init_std=0.0001, seed=1024, device='cpu'):
+                 init_std=0.0001, dice_dim=3, seed=1024, device='cpu'):
         super(DNN, self).__init__()
-        self.activation = activation
         self.dropout_rate = dropout_rate
         self.dropout = nn.Dropout(dropout_rate)
         self.seed = seed
@@ -53,7 +52,7 @@ class DNN(nn.Module):
                 [nn.BatchNorm1d(hidden_units[i + 1]) for i in range(len(hidden_units) - 1)])
         
         self.activation_layers = nn.ModuleList(
-            [activation_layer(self.activation, hidden_units[i + 1]) for i in range(len(hidden_units) - 1)])
+            [activation_layer(activation, hidden_units[i + 1], dice_dim) for i in range(len(hidden_units) - 1)])
 
         for name, tensor in self.linears.named_parameters():
             if 'weight' in name:

--- a/deepctr_torch/layers/core.py
+++ b/deepctr_torch/layers/core.py
@@ -7,6 +7,65 @@ import torch.nn.functional as F
 from .activation import activation_layer
 
 
+class LocalActivationUnit(nn.Module):
+    """The LocalActivationUnit used in DIN with which the representation of
+        user interests varies adaptively given different candidate items.
+
+    Input shape
+        - A list of two 3D tensor with shape:  ``(batch_size, 1, embedding_size)`` and ``(batch_size, T, embedding_size)``
+
+    Output shape
+        - 3D tensor with shape: ``(batch_size, T, 1)``.
+
+    Arguments
+        - **hidden_units**:list of positive integer, the attention net layer number and units in each layer.
+
+        - **activation**: Activation function to use in attention net.
+
+        - **l2_reg**: float between 0 and 1. L2 regularizer strength applied to the kernel weights matrix of attention net.
+
+        - **dropout_rate**: float in [0,1). Fraction of the units to dropout in attention net.
+
+        - **use_bn**: bool. Whether use BatchNormalization before activation or not in attention net.
+
+        - **seed**: A Python integer to use as random seed.
+
+    References
+        - [Zhou G, Zhu X, Song C, et al. Deep interest network for click-through rate prediction[C]//Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining. ACM, 2018: 1059-1068.](https://arxiv.org/pdf/1706.06978.pdf)
+    """
+
+    def __init__(self, hidden_units=[80, 40], embedding_dim=4, activation='Dice', dropout_rate=0, use_bn=False):
+        super(LocalActivationUnit, self).__init__()
+
+        self.dnn1 = DNN(inputs_dim=4*embedding_dim,
+                       hidden_units=hidden_units,
+                       activation=activation,
+                       dropout_rate=0.5,
+                       use_bn=use_bn,
+                       dice_dim=3)
+
+        # self.dnn2 = DNN(inputs_dim=hidden_units[-1],
+        #                  hidden_units=[1],
+        #                  activation=activation,
+        #                  use_bn=use_bn,
+        #                  dice_dim=3)
+
+        self.dense = nn.Linear(hidden_units[-1], 1)
+
+    def forward(self, query, user_behavior):
+        # query ad            : size -> batch_size * 1 * embedding_size
+        # user behavior       : size -> batch_size * time_seq_len * embedding_size
+
+        user_behavior_len = user_behavior.size(1)
+        queries = torch.cat([query for _ in range(user_behavior_len)], dim=1)
+
+        attention_input = torch.cat([queries, user_behavior, queries-user_behavior, queries*user_behavior], dim=-1)
+        attention_output = self.dnn1(attention_input)
+        attention_output = self.dense(attention_output)
+
+        return attention_output
+
+
 class DNN(nn.Module):
     """The Multi Layer Percetron
 

--- a/deepctr_torch/layers/interaction.py
+++ b/deepctr_torch/layers/interaction.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 from ..layers.core import Conv2dSame
 from ..layers.sequence import KMaxPooling
-
+from ..layers.activation import activation_layer
 
 class FM(nn.Module):
     """Factorization Machine models pairwise (order-2) feature interactions
@@ -163,14 +163,14 @@ class CIN(nn.Module):
       Arguments
         - **filed_size** : Positive integer, number of feature groups.
         - **layer_size** : list of int.Feature maps in each layer.
-        - **activation** : activation function used on feature maps.
+        - **activation** : activation function name used on feature maps.
         - **split_half** : bool.if set to False, half of the feature maps in each hidden will connect to output unit.
         - **seed** : A Python integer to use as random seed.
       References
         - [Lian J, Zhou X, Zhang F, et al. xDeepFM: Combining Explicit and Implicit Feature Interactions for Recommender Systems[J]. arXiv preprint arXiv:1803.05170, 2018.] (https://arxiv.org/pdf/1803.05170.pdf)
     """
 
-    def __init__(self, field_size, layer_size=(128, 128), activation=F.relu, split_half=True, l2_reg=1e-5, seed=1024,
+    def __init__(self, field_size, layer_size=(128, 128), activation='relu', split_half=True, l2_reg=1e-5, seed=1024,
                  device='cpu'):
         super(CIN, self).__init__()
         if len(layer_size) == 0:
@@ -180,7 +180,7 @@ class CIN(nn.Module):
         self.layer_size = layer_size
         self.field_nums = [field_size]
         self.split_half = split_half
-        self.activation = activation
+        self.activation = activation_layer(activation)
         self.l2_reg = l2_reg
         self.seed = seed
 

--- a/deepctr_torch/layers/sequence.py
+++ b/deepctr_torch/layers/sequence.py
@@ -1,6 +1,124 @@
 import torch
 import torch.nn as nn
 
+import numpy as np
+
+from .core import LocalActivationUnit
+
+
+class SequencePoolingLayer(nn.Module):
+    """The SequencePoolingLayer is used to apply pooling operation(sum,mean,max) on variable-length sequence feature/multi-value feature.
+
+      Input shape
+        - A list of two  tensor [seq_value,seq_len]
+
+        - seq_value is a 3D tensor with shape: ``(batch_size, T, embedding_size)``
+
+        - seq_len is a 2D tensor with shape : ``(batch_size, 1)``,indicate valid length of each sequence.
+
+      Output shape
+        - 3D tensor with shape: ``(batch_size, 1, embedding_size)``.
+
+      Arguments
+        - **mode**:str.Pooling operation to be used,can be sum,mean or max.
+
+    """
+
+    def __init__(self, mode='mean'):
+        super(SequencePoolingLayer).__init__()
+
+        if mode not in ['sum', 'mean', 'max']:
+            raise ValueError('parameter mode should in [sum, mean, max]')
+        self.mode = mode
+        self.eps = torch.FloatTensor([1e-8])
+
+    def _sequence_mask(self, lengths, maxlen=None, dtype=torch.bool):
+        # Returns a mask tensor representing the first N positions of each cell.
+        if maxlen is None:
+            maxlen = lengths.max()
+        row_vector = torch.arange(0, maxlen, 1)
+        matrix = torch.unsqueeze(lengths, dim=-1)
+        mask = row_vector < matrix
+
+        mask.type(dtype)
+        return mask
+
+    def forward(self, seq_value_len_list):
+        uiseq_embed_list, user_behavior_length = seq_value_len_list                 # [B, T, E], [B, 1]
+        mask = self._sequence_mask(user_behavior_length, dtype=torch.float32)       # [B, 1, maxlen]
+        mask = torch.transpose(mask, 1, 2)                                          # [B, maxlen, 1]
+
+        embedding_size = uiseq_embed_list.shape[-1]
+
+        mask = torch.repeat_interleave(mask, embedding_size, dim=2)                 # [B, maxlen, E]
+
+        uiseq_embed_list *= mask        # [B, maxlen, E]
+        hist = uiseq_embed_list
+
+        if self.mode == 'max':
+            res = torch.max(hist, dim=1, keepdim=True)
+        elif self.mode == 'mean':
+            res = torch.max(hist, dim=1, keepdim=False)
+            res = torch.div(res, user_behavior_length.type(torch.float32) + self.eps)
+            res = torch.unsqueeze(res, dim=1)
+        elif self.mode == 'sum':
+            res = torch.max(hist, dim=1, keepdim=False)
+            res = torch.unsqueeze(res, dim=1)
+        
+        return res
+
+
+class AttentionSequencePoolingLayer(nn.Module):
+    """The Attentional sequence pooling operation used in DIN.
+
+      Input shape
+        - A list of three tensor: [query,keys,keys_length]
+
+        - query is a 3D tensor with shape:  ``(batch_size, 1, embedding_size)``
+
+        - keys is a 3D tensor with shape:   ``(batch_size, T, embedding_size)``
+
+        - keys_length is a 2D tensor with shape: ``(batch_size, 1)``
+
+      Output shape
+        - 3D tensor with shape: ``(batch_size, 1, embedding_size)``
+
+      Arguments
+        - **att_hidden_units**: List of positive integer, the attention net layer number and units in each layer.
+
+        - **embedding_dim**: Dimension of the input embeddings.
+
+        - **activation**: Activation function to use in attention net.
+
+        - **weight_normalization**: bool.Whether normalize the attention score of local activation unit.
+
+      References
+        - [Zhou G, Zhu X, Song C, et al. Deep interest network for click-through rate prediction[C]//Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining. ACM, 2018: 1059-1068.](https://arxiv.org/pdf/1706.06978.pdf)
+    """
+    def __init__(self, att_hidden_units=[80, 40], embedding_dim=4, activation='Dice', weight_normalization=False):
+        super(AttentionSequencePoolingLayer, self).__init__()
+        
+        self.local_att = LocalActivationUnit(hidden_units=att_hidden_units, embedding_dim=embedding_dim, activation=activation)
+
+    def forward(self, query, keys, keys_length):
+        # query: [B, 1, E], keys: [B, T, E], keys_length: [B, 1]
+        # TODO: Mini-batch aware regularization in originial paper [Zhou G, et al. 2018] is not implemented here. As the authors mentioned 
+        #       it is not a must for small dataset as the open-sourced ones.
+        attention_score = self.local_att(query, keys)
+        attention_score = torch.transpose(attention_score, 1, 2)          # B * 1 * T
+        
+        # define mask by length
+        keys_length = keys_length.type(torch.LongTensor)
+        mask = torch.arange(keys.size(1))[None, :] < keys_length[:, None] # [1, T] < [B, 1, 1]  -> [B, 1, T]
+        
+        # mask
+        output = torch.mul(attention_score, mask.type(torch.FloatTensor))  # [B, 1, T]
+
+        # multiply weight
+        output = torch.matmul(output, keys)    # [B, 1, E]
+
+        return output
+        
 
 class KMaxPooling(nn.Module):
     """K Max pooling that selects the k biggest value along the specific axis.

--- a/deepctr_torch/models/afm.py
+++ b/deepctr_torch/models/afm.py
@@ -42,7 +42,7 @@ class AFM(BaseModel):
                                   l2_reg_linear=l2_reg_linear,
                                   l2_reg_embedding=l2_reg_embedding, l2_reg_dnn=0, init_std=init_std,
                                   seed=seed,
-                                  dnn_dropout=0, dnn_activation=F.relu,
+                                  dnn_dropout=0, dnn_activation='relu',
                                   task=task, device=device)
 
         self.use_attention = use_attention

--- a/deepctr_torch/models/autoint.py
+++ b/deepctr_torch/models/autoint.py
@@ -39,7 +39,7 @@ class AutoInt(BaseModel):
 
     def __init__(self, dnn_feature_columns, embedding_size=8, att_layer_num=3, att_embedding_size=8, att_head_num=2,
                  att_res=True,
-                 dnn_hidden_units=(256, 128), dnn_activation=F.relu,
+                 dnn_hidden_units=(256, 128), dnn_activation='relu',
                  l2_reg_dnn=0, l2_reg_embedding=1e-5, dnn_use_bn=False, dnn_dropout=0, init_std=0.0001, seed=1024,
                  task='binary', device='cpu'):
 

--- a/deepctr_torch/models/basemodel.py
+++ b/deepctr_torch/models/basemodel.py
@@ -339,7 +339,8 @@ class BaseModel(nn.Module):
         return sparse_embedding_list + varlen_sparse_embedding_list, dense_value_list
 
     def create_embedding_matrix(self, feature_columns, embedding_size, init_std=0.0001, sparse=False):
-
+        # Return nn.ModuleDict: for sparse features, {embedding_name: nn.Embedding}
+        # for varlen sparse features, {embedding_name: nn.EmbeddingBag}
         sparse_feature_columns = list(
             filter(lambda x: isinstance(x, SparseFeat), feature_columns)) if len(feature_columns) else []
 

--- a/deepctr_torch/models/ccpm.py
+++ b/deepctr_torch/models/ccpm.py
@@ -44,7 +44,7 @@ class CCPM(BaseModel):
     def __init__(self, linear_feature_columns, dnn_feature_columns, embedding_size=8, conv_kernel_width=(6, 5),
                  conv_filters=(4, 4),
                  dnn_hidden_units=(256,), l2_reg_linear=1e-5, l2_reg_embedding=1e-5, l2_reg_dnn=0, dnn_dropout=0,
-                 init_std=0.0001, seed=1024, task='binary', device='cpu', dnn_use_bn=False, dnn_activation=F.relu):
+                 init_std=0.0001, seed=1024, task='binary', device='cpu', dnn_use_bn=False, dnn_activation='relu'):
 
         super(CCPM, self).__init__(linear_feature_columns, dnn_feature_columns, embedding_size=embedding_size,
                                    dnn_hidden_units=dnn_hidden_units,

--- a/deepctr_torch/models/dcn.py
+++ b/deepctr_torch/models/dcn.py
@@ -40,7 +40,7 @@ class DCN(BaseModel):
                  dnn_hidden_units=(128, 128), l2_reg_linear=0.00001,
                  l2_reg_embedding=0.00001, l2_reg_cross=0.00001, l2_reg_dnn=0, init_std=0.0001, seed=1024,
                  dnn_dropout=0,
-                 dnn_activation=F.relu, dnn_use_bn=False, task='binary', device='cpu'):
+                 dnn_activation='relu', dnn_use_bn=False, task='binary', device='cpu'):
 
         super(DCN, self).__init__(linear_feature_columns=[],
                                   dnn_feature_columns=dnn_feature_columns,

--- a/deepctr_torch/models/deepfm.py
+++ b/deepctr_torch/models/deepfm.py
@@ -40,7 +40,7 @@ class DeepFM(BaseModel):
                  dnn_hidden_units=(256, 128),
                  l2_reg_linear=0.00001, l2_reg_embedding=0.00001, l2_reg_dnn=0, init_std=0.0001, seed=1024,
                  dnn_dropout=0,
-                 dnn_activation=F.relu, dnn_use_bn=False, task='binary', device='cpu'):
+                 dnn_activation='relu', dnn_use_bn=False, task='binary', device='cpu'):
 
         super(DeepFM, self).__init__(linear_feature_columns, dnn_feature_columns, embedding_size=embedding_size,
                                      dnn_hidden_units=dnn_hidden_units,

--- a/deepctr_torch/models/din.py
+++ b/deepctr_torch/models/din.py
@@ -1,0 +1,126 @@
+# -*- coding:utf-8 -*-
+"""
+Author:
+    Yuef Zhang
+Reference:
+    [1] Zhou G, Zhu X, Song C, et al. Deep interest network for click-through rate prediction[C]//Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining. ACM, 2018: 1059-1068. (https://arxiv.org/pdf/1706.06978.pdf)
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .basemodel import BaseModel
+from ..inputs import create_embedding_matrix, get_varlen_pooling_list, embedding_lookup, get_dense_input, varlen_embedding_lookup, SparseFeat, DenseFeat, VarLenSparseFeat, combined_dnn_input
+from ..layers import FM, DNN
+from ..layers.sequence import AttentionSequencePoolingLayer
+
+
+class DIN(BaseModel):
+    """Instantiates the Deep Interest Network architecture.
+
+    :param dnn_feature_columns: An iterable containing all the features used by deep part of the model.
+    :param history_feature_list: list,to indicate  sequence sparse field
+    :param dnn_use_bn: bool. Whether use BatchNormalization before activation or not in deep net
+    :param dnn_hidden_units: list,list of positive integer or empty list, the layer number and units in each layer of deep net
+    :param dnn_activation: Activation function to use in deep net
+    :param att_hidden_size: list,list of positive integer , the layer number and units in each layer of attention net
+    :param att_activation: Activation function to use in attention net
+    :param att_weight_normalization: bool.Whether normalize the attention score of local activation unit.
+    :param l2_reg_dnn: float. L2 regularizer strength applied to DNN
+    :param l2_reg_embedding: float. L2 regularizer strength applied to embedding vector
+    :param dnn_dropout: float in [0,1), the probability we will drop out a given DNN coordinate.
+    :param init_std: float,to use as the initialize std of embedding vector
+    :param seed: integer ,to use as random seed.
+    :param task: str, ``"binary"`` for  binary logloss or  ``"regression"`` for regression loss
+    :return:  A PyTorch model instance.
+
+    """
+    def __init__(self,
+                 dnn_feature_columns, 
+                 history_feature_list,
+                 dnn_use_bn=False,
+                 embedding_size=8,
+                 dnn_hidden_units=(256, 128),
+                 dnn_activation='relu',
+                 att_hidden_size=[80,40],
+                 att_activation='Dice',
+                 l2_reg_dnn=0.0,
+                 init_std=0.0001,
+                 dnn_dropout=0,
+                 task='binary', device='cpu'):
+
+        super(DIN, self).__init__([], dnn_feature_columns, embedding_size=embedding_size,
+                                dnn_hidden_units=dnn_hidden_units, l2_reg_linear=0,
+                                l2_reg_dnn=l2_reg_dnn, init_std=init_std,
+                                dnn_dropout=dnn_dropout, dnn_activation=dnn_activation,
+                                task=task, device=device)
+       
+        sparse_feature_columns = list(filter(lambda x:isinstance(x,SparseFeat),dnn_feature_columns)) if dnn_feature_columns else []
+        varlen_sparse_feature_columns = list(filter(lambda x: isinstance(x, VarLenSparseFeat), dnn_feature_columns)) if dnn_feature_columns else []
+
+        history_feature_columns = []
+        sparse_varlen_feature_columns = []
+        history_fc_names = list(map(lambda x: "hist_" + x, history_feature_list))
+        for fc in varlen_sparse_feature_columns:
+            feature_name = fc.name
+            if feature_name in history_fc_names:
+                history_feature_columns.append(fc)
+            else:
+                sparse_varlen_feature_columns.append(fc)
+
+        history_feature_columns = []
+        sparse_varlen_feature_columns = []
+        history_fc_names = list(map(lambda x: "hist_" + x, history_feature_list))
+
+        query_emb_list = embedding_lookup(self.embedding_dict, self.feature_index, sparse_feature_columns, 
+                                          history_feature_list, history_feature_list, to_list=True)
+        keys_emb_list = embedding_lookup(self.embedding_dict, self.feature_index, history_feature_columns,
+                                         history_fc_names, history_fc_names, to_list=True)
+        dnn_input_emb_list = embedding_lookup(self.embedding_dict, self.feature_index, sparse_feature_columns,
+                                              mask_feat_list=history_feature_list, to_list=True)
+
+        sequence_embed_dict = varlen_embedding_lookup(self.embedding_dict, self.feature_index, sparse_varlen_feature_columns)
+        sequence_embed_list = get_varlen_pooling_list(sequence_embed_dict, self.feature_index, sparse_varlen_feature_columns,to_list=True)
+        
+        dnn_input_emb_list += sequence_embed_list
+
+        # concatenate
+        self.query_emb = torch.cat(query_emb_list, dim=-1)          # [B, 1, E]
+        self.keys_emb = torch.cat(keys_emb_list, dim=-1)            # [B, T, E]
+        self.keys_length = torch.ones((self.query_emb.size(0), 1))      # [B, 1]
+        self.deep_input_emb = torch.cat(dnn_input_emb_list, dim=-1)
+
+
+        self.atten = AttentionSequencePoolingLayer(att_hidden_units=att_hidden_size,
+                                                   embedding_dim=embedding_size,
+                                                   activation=att_activation)
+        
+        self.dnn = DNN(inputs_dim=self.compute_input_dim(dnn_feature_columns, embedding_size),
+                       hidden_units=dnn_hidden_units,
+                       activation=dnn_activation,
+                       dropout_rate=dnn_dropout,
+                       l2_reg=l2_reg_dnn)
+        self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False).to(device)
+        self.to(device)
+
+    def forward(self, X):
+        sparse_embedding_list, dense_value_list = self.input_from_feature_columns(X, self.dnn_feature_columns,
+                                                                                  self.embedding_dict)
+
+        hist = self.atten(self.query_emb, self.keys_emb, self.keys_length)
+
+        deep_input_emb = torch.cat((self.deep_input_emb, hist), dim=-1)
+        deep_input_emb = deep_input_emb.view(deep_input_emb.size(0), -1)
+
+        dnn_input = combined_dnn_input([deep_input_emb], dense_value_list)
+        dnn_output = self.dnn(dnn_input)
+        dnn_logit = self.dnn_linear(dnn_output)
+
+        y_pred = self.out(dnn_logit)
+
+        return y_pred
+
+
+if __name__ == '__main__':
+    pass
+

--- a/deepctr_torch/models/fibinet.py
+++ b/deepctr_torch/models/fibinet.py
@@ -40,7 +40,7 @@ class FiBiNET(BaseModel):
 
     def __init__(self, linear_feature_columns, dnn_feature_columns, embedding_size=8, bilinear_type='interaction',
                  reduction_ratio=3, dnn_hidden_units=(128, 128), l2_reg_linear=1e-5,
-                 l2_reg_embedding=1e-5, l2_reg_dnn=0, init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation=F.relu,
+                 l2_reg_embedding=1e-5, l2_reg_dnn=0, init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation='relu',
                  task='binary', device='cpu'):
         super(FiBiNET, self).__init__(linear_feature_columns, dnn_feature_columns, embedding_size=embedding_size,
                                       dnn_hidden_units=dnn_hidden_units,

--- a/deepctr_torch/models/nfm.py
+++ b/deepctr_torch/models/nfm.py
@@ -38,7 +38,7 @@ class NFM(BaseModel):
     def __init__(self,
                  linear_feature_columns, dnn_feature_columns, embedding_size=8, dnn_hidden_units=(128, 128),
                  l2_reg_embedding=1e-5, l2_reg_linear=1e-5, l2_reg_dnn=0, init_std=0.0001, seed=1024, bi_dropout=0,
-                 dnn_dropout=0, dnn_activation=F.relu, task='binary', device='cpu'):
+                 dnn_dropout=0, dnn_activation='relu', task='binary', device='cpu'):
         super(NFM, self).__init__(linear_feature_columns, dnn_feature_columns, embedding_size=embedding_size,
                                   dnn_hidden_units=dnn_hidden_units,
                                   l2_reg_linear=l2_reg_linear,

--- a/deepctr_torch/models/onn.py
+++ b/deepctr_torch/models/onn.py
@@ -56,7 +56,7 @@ class ONN(BaseModel):
     def __init__(self, linear_feature_columns, dnn_feature_columns, embedding_size=4,
                  dnn_hidden_units=(128, 128),
                  l2_reg_embedding=1e-5, l2_reg_linear=1e-5, l2_reg_dnn=0,
-                 dnn_dropout=0, init_std=0.0001, seed=1024, dnn_use_bn=False, dnn_activation=F.relu,
+                 dnn_dropout=0, init_std=0.0001, seed=1024, dnn_use_bn=False, dnn_activation='relu',
                  task='binary', device='cpu'):
         super(ONN, self).__init__(linear_feature_columns, dnn_feature_columns, embedding_size=embedding_size,
                                   dnn_hidden_units=dnn_hidden_units,

--- a/deepctr_torch/models/pnn.py
+++ b/deepctr_torch/models/pnn.py
@@ -37,7 +37,7 @@ class PNN(BaseModel):
     """
 
     def __init__(self, dnn_feature_columns, embedding_size=8, dnn_hidden_units=(128, 128), l2_reg_embedding=1e-5, l2_reg_dnn=0,
-                 init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation=F.relu, use_inner=True, use_outter=False,
+                 init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation='relu', use_inner=True, use_outter=False,
                  kernel_type='mat', task='binary', device='cpu',):
 
         super(PNN, self).__init__([], dnn_feature_columns, embedding_size=embedding_size,

--- a/deepctr_torch/models/wdl.py
+++ b/deepctr_torch/models/wdl.py
@@ -35,7 +35,7 @@ class WDL(BaseModel):
     def __init__(self,
                  linear_feature_columns, dnn_feature_columns, embedding_size=8, dnn_hidden_units=(256, 128),
                  l2_reg_linear=1e-5,
-                 l2_reg_embedding=1e-5, l2_reg_dnn=0, init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation=F.relu,dnn_use_bn=False,
+                 l2_reg_embedding=1e-5, l2_reg_dnn=0, init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation='relu', dnn_use_bn=False,
                  task='binary', device='cpu'):
 
         super(WDL, self).__init__(linear_feature_columns, dnn_feature_columns, embedding_size=embedding_size,

--- a/deepctr_torch/models/xdeepfm.py
+++ b/deepctr_torch/models/xdeepfm.py
@@ -42,7 +42,7 @@ class xDeepFM(BaseModel):
     def __init__(self, linear_feature_columns, dnn_feature_columns, embedding_size=8, dnn_hidden_units=(256, 256),
                  cin_layer_size=(256, 128,), cin_split_half=True, cin_activation='relu', l2_reg_linear=0.00001,
                  l2_reg_embedding=0.00001, l2_reg_dnn=0, l2_reg_cin=0, init_std=0.0001, seed=1024, dnn_dropout=0,
-                 dnn_activation=F.relu, dnn_use_bn=False, task='binary', device='cpu'):
+                 dnn_activation='relu', dnn_use_bn=False, task='binary', device='cpu'):
 
         super(xDeepFM, self).__init__(linear_feature_columns, dnn_feature_columns, embedding_size=embedding_size,
                                       dnn_hidden_units=dnn_hidden_units,

--- a/deepctr_torch/models/xdeepfm.py
+++ b/deepctr_torch/models/xdeepfm.py
@@ -40,7 +40,7 @@ class xDeepFM(BaseModel):
     """
 
     def __init__(self, linear_feature_columns, dnn_feature_columns, embedding_size=8, dnn_hidden_units=(256, 256),
-                 cin_layer_size=(256, 128,), cin_split_half=True, cin_activation=F.relu, l2_reg_linear=0.00001,
+                 cin_layer_size=(256, 128,), cin_split_half=True, cin_activation='relu', l2_reg_linear=0.00001,
                  l2_reg_embedding=0.00001, l2_reg_dnn=0, l2_reg_cin=0, init_std=0.0001, seed=1024, dnn_dropout=0,
                  dnn_activation=F.relu, dnn_use_bn=False, task='binary', device='cpu'):
 

--- a/tests/layers/activation_test.py
+++ b/tests/layers/activation_test.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from deepctr_torch.layers import activation
+

--- a/tests/models/xDeepFM_test.py
+++ b/tests/models/xDeepFM_test.py
@@ -10,7 +10,7 @@ from ..utils import get_test_data, SAMPLE_SIZE, check_model
     [((), (), True, 'linear', 1, 2),
         ((8,), (), True, 'linear', 1, 1),
         ((), (8,), True, 'linear', 2, 2),
-        ((8,), (8,), False, F.relu, 2, 0)]
+        ((8,), (8,), False, 'relu', 2, 0)]
 )
 def test_xDeepFM(dnn_hidden_units, cin_layer_size, cin_split_half, cin_activation, sparse_feature_num, dense_feature_dim):
 


### PR DESCRIPTION
Add Deep Interest Network (DIN) model [1].

## Add
1. Add Dice activation layer
2. Add Local Activation Unit
3. Add Sequenence Pooling Layer & Attention Sequence Pooling Layer in `layers/sequence.py`
4. Add embedding lookup functions (embedding_lookup, varlen_embedding_lookup, get_varlen_pooling_list) in `inputs.py`
4. Add `model/DIN.py`

## Revise
1. Add `group_name` attribute for SparseFeat and VarLenSparseFeat in `inputs.py`
2. Refactor activation layer construct method of DNN module in `layers/core.py`
    - Revise all models which use DNN module

## TODO
- [ ] To add Mini-batch Aware Regularization
- [ ] To add Hash layer
- [ ] To add unit test for layers
- [ ] To add unit test for DIN model

## Reference
- [1] [Zhou G, Zhu X, Song C, et al. Deep interest network for click-through rate prediction[C]//Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining. ACM, 2018: 1059-1068.](https://arxiv.org/pdf/1706.06978.pdf)