### PR TITLE
Dev afn weiyucheng

### DIFF
--- a/deepctr_torch/layers/interaction.py
+++ b/deepctr_torch/layers/interaction.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ..layers.activation import activation_layer
-from ..layers.core import Conv2dSame
+from ..layers.core import Conv2dSame, DNN
 from ..layers.sequence import KMaxPooling
 
 
@@ -341,7 +341,8 @@ class InteractingLayer(nn.Module):
             - [Song W, Shi C, Xiao Z, et al. AutoInt: Automatic Feature Interaction Learning via Self-Attentive Neural Networks[J]. arXiv preprint arXiv:1810.11921, 2018.](https://arxiv.org/abs/1810.11921)
     """
 
-    def __init__(self, in_features, att_embedding_size=8, head_num=2, use_res=True, scaling=False, seed=1024, device='cpu'):
+    def __init__(self, in_features, att_embedding_size=8, head_num=2, use_res=True, scaling=False, seed=1024,
+                 device='cpu'):
         super(InteractingLayer, self).__init__()
         if head_num <= 0:
             raise ValueError('head_num must be a int > 0')
@@ -727,3 +728,57 @@ class ConvLayer(nn.Module):
 
     def forward(self, inputs):
         return self.conv_layer(inputs)
+
+
+class AFNLayer(nn.Module):
+    """Adaptive factorization network models arbitrary-order cross features with logarithmic transformation layer.
+
+      Input shape
+        - 3D tensor with shape: ``(batch_size,field_size,embedding_size)``.
+      Output shape
+        - 2D tensor with shape: ``(batch_size, 1)``.
+      Arguments
+        - **field_size** : positive integer, number of feature groups
+        - **embedding_size** : positive integer, embedding size of sparse features
+        - **ltl_hidden_size** : integer, the number of logarithmic neurons in AFN
+        - **dnn_hidden_units** : list, list of positive integer or empty list, the layer number and units in each layer of DNN layers in AFN
+        - **dnn_activation** : activation function to use in DNN layers in AFN
+        - **l2_reg_dnn** : float, L2 regularizer strength applied to DNN layers in AFN
+        - **dnn_dropout** : float in [0,1), the probability we will drop out a given DNN coordinate
+        - **init_std** : float,to use as the initialize std of embedding vector
+        - **device** : str, ``"cpu"`` or ``"cuda:0"``
+      References
+        - Cheng, W., Shen, Y. and Huang, L. 2020. Adaptive Factorization Network: Learning Adaptive-Order Feature
+         Interactions. Proceedings of the AAAI Conference on Artificial Intelligence. 34, 04 (Apr. 2020), 3609-3616.
+    """
+
+    def __init__(self, field_size, embedding_size, ltl_hidden_size, dnn_hidden_units,
+                 dnn_activation, l2_reg_dnn, dnn_dropout, init_std, device):
+        super(AFNLayer, self).__init__()
+
+        self.ltl_weights = nn.Parameter(torch.Tensor(field_size, ltl_hidden_size))
+        self.ltl_biases = nn.Parameter(torch.Tensor(1, 1, ltl_hidden_size))
+        self.bn = nn.ModuleList([nn.BatchNorm1d(embedding_size) for i in range(2)])
+        self.dnn = DNN(embedding_size * ltl_hidden_size, dnn_hidden_units,
+                       activation=dnn_activation, l2_reg=l2_reg_dnn, dropout_rate=dnn_dropout, use_bn=True,
+                       init_std=init_std, device=device)
+        self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1)
+        nn.init.xavier_normal_(self.ltl_weights, )
+        nn.init.zeros_(self.ltl_biases, )
+
+    def forward(self, inputs):
+        # Avoid numeric overflow
+        afn_input = torch.clamp(torch.abs(inputs), min=1e-4, max=float("Inf"))
+        # Transpose to shape: ``(batch_size,embedding_size,field_size)``
+        afn_input_trans = torch.transpose(afn_input, 1, 2)
+        # Logarithmic transformation layer
+        ltl_result = torch.log(afn_input_trans)
+        ltl_result = self.bn[0](ltl_result)
+        ltl_result = torch.matmul(ltl_result, self.ltl_weights) + self.ltl_biases
+        ltl_result = torch.exp(ltl_result)
+        ltl_result = self.bn[1](ltl_result)
+        ltl_result = torch.flatten(ltl_result, start_dim=1)
+        # DNN layers
+        afn_result = self.dnn(ltl_result)
+        afn_result = self.dnn_linear(afn_result)
+        return afn_result

--- a/deepctr_torch/layers/interaction.py
+++ b/deepctr_torch/layers/interaction.py
@@ -341,8 +341,7 @@ class InteractingLayer(nn.Module):
             - [Song W, Shi C, Xiao Z, et al. AutoInt: Automatic Feature Interaction Learning via Self-Attentive Neural Networks[J]. arXiv preprint arXiv:1810.11921, 2018.](https://arxiv.org/abs/1810.11921)
     """
 
-    def __init__(self, in_features, att_embedding_size=8, head_num=2, use_res=True, scaling=False, seed=1024,
-                 device='cpu'):
+    def __init__(self, in_features, att_embedding_size=8, head_num=2, use_res=True, scaling=False, seed=1024, device='cpu'):
         super(InteractingLayer, self).__init__()
         if head_num <= 0:
             raise ValueError('head_num must be a int > 0')
@@ -730,8 +729,8 @@ class ConvLayer(nn.Module):
         return self.conv_layer(inputs)
 
 
-class AFNLayer(nn.Module):
-    """Adaptive factorization network models arbitrary-order cross features with logarithmic transformation layer.
+class LogTransformLayer(nn.Module):
+    """Logarithmic Transformation Layer in Adaptive factorization network, which models arbitrary-order cross features.
 
       Input shape
         - 3D tensor with shape: ``(batch_size,field_size,embedding_size)``.
@@ -741,28 +740,17 @@ class AFNLayer(nn.Module):
         - **field_size** : positive integer, number of feature groups
         - **embedding_size** : positive integer, embedding size of sparse features
         - **ltl_hidden_size** : integer, the number of logarithmic neurons in AFN
-        - **dnn_hidden_units** : list, list of positive integer or empty list, the layer number and units in each layer of DNN layers in AFN
-        - **dnn_activation** : activation function to use in DNN layers in AFN
-        - **l2_reg_dnn** : float, L2 regularizer strength applied to DNN layers in AFN
-        - **dnn_dropout** : float in [0,1), the probability we will drop out a given DNN coordinate
-        - **init_std** : float,to use as the initialize std of embedding vector
-        - **device** : str, ``"cpu"`` or ``"cuda:0"``
       References
         - Cheng, W., Shen, Y. and Huang, L. 2020. Adaptive Factorization Network: Learning Adaptive-Order Feature
          Interactions. Proceedings of the AAAI Conference on Artificial Intelligence. 34, 04 (Apr. 2020), 3609-3616.
     """
 
-    def __init__(self, field_size, embedding_size, ltl_hidden_size, dnn_hidden_units,
-                 dnn_activation, l2_reg_dnn, dnn_dropout, init_std, device):
-        super(AFNLayer, self).__init__()
+    def __init__(self, field_size, embedding_size, ltl_hidden_size):
+        super(LogTransformLayer, self).__init__()
 
         self.ltl_weights = nn.Parameter(torch.Tensor(field_size, ltl_hidden_size))
         self.ltl_biases = nn.Parameter(torch.Tensor(1, 1, ltl_hidden_size))
         self.bn = nn.ModuleList([nn.BatchNorm1d(embedding_size) for i in range(2)])
-        self.dnn = DNN(embedding_size * ltl_hidden_size, dnn_hidden_units,
-                       activation=dnn_activation, l2_reg=l2_reg_dnn, dropout_rate=dnn_dropout, use_bn=True,
-                       init_std=init_std, device=device)
-        self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1)
         nn.init.xavier_normal_(self.ltl_weights, )
         nn.init.zeros_(self.ltl_biases, )
 
@@ -778,7 +766,4 @@ class AFNLayer(nn.Module):
         ltl_result = torch.exp(ltl_result)
         ltl_result = self.bn[1](ltl_result)
         ltl_result = torch.flatten(ltl_result, start_dim=1)
-        # DNN layers
-        afn_result = self.dnn(ltl_result)
-        afn_result = self.dnn_linear(afn_result)
-        return afn_result
+        return ltl_result

--- a/deepctr_torch/models/__init__.py
+++ b/deepctr_torch/models/__init__.py
@@ -15,3 +15,4 @@ from .pnn import PNN
 from .ccpm import CCPM
 from .dien import DIEN
 from .din import DIN
+from .afn import AFN

--- a/deepctr_torch/models/afn.py
+++ b/deepctr_torch/models/afn.py
@@ -1,0 +1,317 @@
+# -*- coding:utf-8 -*-
+"""
+Author:
+    Weiyu Cheng, weiyu_cheng@sjtu.edu.cn
+Reference:
+    [1] Cheng, W., Shen, Y. and Huang, L. 2020. Adaptive Factorization Network: Learning Adaptive-Order Feature
+         Interactions. Proceedings of the AAAI Conference on Artificial Intelligence. 34, 04 (Apr. 2020), 3609-3616.
+"""
+import time
+
+from tqdm import tqdm
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.utils.data as Data
+from torch.utils.data import DataLoader
+
+try:
+    from tensorflow.python.keras.callbacks import CallbackList
+except ImportError:
+    from tensorflow.python.keras._impl.keras.callbacks import CallbackList
+
+from .basemodel import BaseModel, create_embedding_matrix
+from ..inputs import combined_dnn_input
+from ..layers import AFNLayer, DNN, PredictionLayer
+from ..layers.utils import slice_arrays
+
+
+class AFN(BaseModel):
+    """Instantiates the Adaptive Factorization Network architecture.
+
+    :param linear_feature_columns: An iterable containing all the features used by linear part of the model.
+    :param dnn_feature_columns: An iterable containing all the features used by deep part of the model.
+    :param use_afn: bool, use AFN part or not
+    :param ltl_hidden_size: integer, the number of logarithmic neurons in AFN
+    :param afn_dnn_hidden_units: list, list of positive integer or empty list, the layer number and units in each layer of DNN layers in AFN
+    :param dnn_hidden_units: list, list of positive integer or empty list, the layer number and units in each layer of DNN model of AFN+
+    :param l2_reg_linear: float. L2 regularizer strength applied to linear part
+    :param l2_reg_embedding: float. L2 regularizer strength applied to embedding vector
+    :param l2_reg_dnn: float. L2 regularizer strength applied to DNN
+    :param init_std: float,to use as the initialize std of embedding vector
+    :param seed: integer ,to use as random seed.
+    :param dnn_dropout: float in [0,1), the probability we will drop out a given DNN coordinate.
+    :param dnn_activation: Activation function to use in DNN
+    :param dnn_use_bn: bool. Whether use BatchNormalization before activation or not in DNN
+    :param task: str, ``"binary"`` for  binary logloss or  ``"regression"`` for regression loss
+    :param device: str, ``"cpu"`` or ``"cuda:0"``
+    :param gpus: list of int or torch.device for multiple gpus. If None, run on `device`. `gpus[0]` should be the same gpu with `device`.
+    :return: A PyTorch model instance.
+
+    """
+
+    def __init__(self,
+                 linear_feature_columns, dnn_feature_columns,
+                 use_afn=True, ltl_hidden_size=600, afn_dnn_hidden_units=(400, 400, 400),
+                 dnn_hidden_units=(256, 128), l2_reg_linear=0.00001, l2_reg_embedding=0.00001, l2_reg_dnn=0,
+                 init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation='relu', dnn_use_bn=True,
+                 task='binary', device='cpu', gpus=None):
+
+        super(AFN, self).__init__(linear_feature_columns, dnn_feature_columns, l2_reg_linear=l2_reg_linear,
+                                  l2_reg_embedding=l2_reg_embedding, init_std=init_std, seed=seed, task=task,
+                                  device=device, gpus=gpus)
+
+        self.use_afn = use_afn
+        self.use_dnn = len(dnn_feature_columns) > 0 and len(dnn_hidden_units) > 0
+        if use_afn:
+            self.afn = AFNLayer(len(self.embedding_dict), self.embedding_size, ltl_hidden_size, afn_dnn_hidden_units,
+                                dnn_activation, l2_reg_dnn, dnn_dropout, init_std, device)
+
+        if self.use_dnn:
+            self.dnn_embedding_dict = create_embedding_matrix(dnn_feature_columns, init_std, sparse=False,
+                                                              device=device)
+            self.dnn = DNN(self.compute_input_dim(dnn_feature_columns), dnn_hidden_units,
+                           activation=dnn_activation, l2_reg=l2_reg_dnn, dropout_rate=dnn_dropout, use_bn=dnn_use_bn,
+                           init_std=init_std, device=device)
+            self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False).to(device)
+            self.add_regularization_weight(
+                filter(lambda x: 'weight' in x[0] and 'bn' not in x[0], self.dnn.named_parameters()), l2=l2_reg_dnn)
+            self.add_regularization_weight(self.dnn_linear.weight, l2=l2_reg_dnn)
+
+        self.w_afn = nn.Parameter(torch.Tensor([0.5]))
+        self.w_dnn = nn.Parameter(torch.Tensor([0.5]))
+        self.b = nn.Parameter(torch.Tensor([0.]))
+        self.afn_out = PredictionLayer(task, )
+        self.dnn_out = PredictionLayer(task, )
+        self.ensemble_out = PredictionLayer(task, )
+        self.to(device)
+
+    def forward(self, X):
+
+        sparse_embedding_list, _ = self.input_from_feature_columns(X, self.dnn_feature_columns, self.embedding_dict)
+        self.sparse_embedding_list = sparse_embedding_list
+        dnn_sparse_embedding_list, dnn_dense_value_list = self.input_from_feature_columns(X, self.dnn_feature_columns,
+                                                                                          self.dnn_embedding_dict)
+        y_pred = 0
+        afn_pred = None
+        dnn_pred = None
+
+        if self.use_afn and len(sparse_embedding_list) > 0:
+            afn_input = torch.cat(sparse_embedding_list, dim=1)
+            afn_logit = self.afn(afn_input)
+            afn_pred = self.afn_out(afn_logit)
+            y_pred += self.w_afn * afn_logit.detach()
+
+        if self.use_dnn:
+            dnn_input = combined_dnn_input(
+                dnn_sparse_embedding_list, dnn_dense_value_list)
+            dnn_output = self.dnn(dnn_input)
+            dnn_logit = self.dnn_linear(dnn_output)
+            dnn_pred = self.dnn_out(dnn_logit)
+            y_pred += self.w_dnn * dnn_logit.detach()
+
+        y_pred = self.ensemble_out(y_pred + self.b)
+
+        # Output the prediction of the ensembled model, afn, and dnn, respectively, for the ensembled training in AFN paper.
+        return y_pred, afn_pred, dnn_pred
+
+    def fit(self, x=None, y=None, batch_size=None, epochs=1, verbose=1, initial_epoch=0, validation_split=0.,
+            validation_data=None, shuffle=True, callbacks=None):
+        """
+
+        :param x: Numpy array of training data (if the model has a single input), or list of Numpy arrays (if the model has multiple inputs).If input layers in the model are named, you can also pass a
+            dictionary mapping input names to Numpy arrays.
+        :param y: Numpy array of target (label) data (if the model has a single output), or list of Numpy arrays (if the model has multiple outputs).
+        :param batch_size: Integer or `None`. Number of samples per gradient update. If unspecified, `batch_size` will default to 256.
+        :param epochs: Integer. Number of epochs to train the model. An epoch is an iteration over the entire `x` and `y` data provided. Note that in conjunction with `initial_epoch`, `epochs` is to be understood as "final epoch". The model is not trained for a number of iterations given by `epochs`, but merely until the epoch of index `epochs` is reached.
+        :param verbose: Integer. 0, 1, or 2. Verbosity mode. 0 = silent, 1 = progress bar, 2 = one line per epoch.
+        :param initial_epoch: Integer. Epoch at which to start training (useful for resuming a previous training run).
+        :param validation_split: Float between 0 and 1. Fraction of the training data to be used as validation data. The model will set apart this fraction of the training data, will not train on it, and will evaluate the loss and any model metrics on this data at the end of each epoch. The validation data is selected from the last samples in the `x` and `y` data provided, before shuffling.
+        :param validation_data: tuple `(x_val, y_val)` or tuple `(x_val, y_val, val_sample_weights)` on which to evaluate the loss and any model metrics at the end of each epoch. The model will not be trained on this data. `validation_data` will override `validation_split`.
+        :param shuffle: Boolean. Whether to shuffle the order of the batches at the beginning of each epoch.
+        :param callbacks: List of `deepctr_torch.callbacks.Callback` instances. List of callbacks to apply during training and validation (if ). See [callbacks](https://tensorflow.google.cn/api_docs/python/tf/keras/callbacks). Now available: `EarlyStopping` , `ModelCheckpoint`
+
+        :return: A `History` object. Its `History.history` attribute is a record of training loss values and metrics values at successive epochs, as well as validation loss values and validation metrics values (if applicable).
+        """
+        if isinstance(x, dict):
+            x = [x[feature] for feature in self.feature_index]
+
+        do_validation = False
+        if validation_data:
+            do_validation = True
+            if len(validation_data) == 2:
+                val_x, val_y = validation_data
+                val_sample_weight = None
+            elif len(validation_data) == 3:
+                val_x, val_y, val_sample_weight = validation_data  # pylint: disable=unpacking-non-sequence
+            else:
+                raise ValueError(
+                    'When passing a `validation_data` argument, '
+                    'it must contain either 2 items (x_val, y_val), '
+                    'or 3 items (x_val, y_val, val_sample_weights), '
+                    'or alternatively it could be a dataset or a '
+                    'dataset or a dataset iterator. '
+                    'However we received `validation_data=%s`' % validation_data)
+            if isinstance(val_x, dict):
+                val_x = [val_x[feature] for feature in self.feature_index]
+
+        elif validation_split and 0. < validation_split < 1.:
+            do_validation = True
+            if hasattr(x[0], 'shape'):
+                split_at = int(x[0].shape[0] * (1. - validation_split))
+            else:
+                split_at = int(len(x[0]) * (1. - validation_split))
+            x, val_x = (slice_arrays(x, 0, split_at),
+                        slice_arrays(x, split_at))
+            y, val_y = (slice_arrays(y, 0, split_at),
+                        slice_arrays(y, split_at))
+
+        else:
+            val_x = []
+            val_y = []
+        for i in range(len(x)):
+            if len(x[i].shape) == 1:
+                x[i] = np.expand_dims(x[i], axis=1)
+
+        train_tensor_data = Data.TensorDataset(
+            torch.from_numpy(
+                np.concatenate(x, axis=-1)),
+            torch.from_numpy(y))
+        if batch_size is None:
+            batch_size = 256
+
+        model = self.train()
+        loss_func = self.loss_func
+        optim = self.optim
+
+        if self.gpus:
+            print('parallel running on these gpus:', self.gpus)
+            model = torch.nn.DataParallel(model, device_ids=self.gpus)
+            batch_size *= len(self.gpus)  # input `batch_size` is batch_size per gpu
+        else:
+            print(self.device)
+
+        train_loader = DataLoader(
+            dataset=train_tensor_data, shuffle=shuffle, batch_size=batch_size)
+
+        sample_num = len(train_tensor_data)
+        steps_per_epoch = (sample_num - 1) // batch_size + 1
+
+        # configure callbacks
+        callbacks = (callbacks or []) + [self.history]  # add history callback
+        callbacks = CallbackList(callbacks)
+        callbacks.on_train_begin()
+        callbacks.set_model(self)
+        if not hasattr(callbacks, 'model'):
+            callbacks.__setattr__('model', self)
+        callbacks.model.stop_training = False
+
+        # Train
+        print("Train on {0} samples, validate on {1} samples, {2} steps per epoch".format(
+            len(train_tensor_data), len(val_y), steps_per_epoch))
+        for epoch in range(initial_epoch, epochs):
+            callbacks.on_epoch_begin(epoch)
+            epoch_logs = {}
+            start_time = time.time()
+            loss_epoch = 0
+            total_loss_epoch = 0
+            train_result = {}
+            try:
+                with tqdm(enumerate(train_loader), disable=verbose != 1) as t:
+                    for _, (x_train, y_train) in t:
+                        x = x_train.to(self.device).float()
+                        y = y_train.to(self.device).float()
+
+                        y_pred, afn_pred, dnn_pred = [output.squeeze() for output in model(x)]
+                        #                         y_pred = model(x).squeeze()
+
+                        optim.zero_grad()
+                        loss = loss_func(y_pred, y.squeeze(), reduction='sum')
+                        if self.use_afn and len(self.sparse_embedding_list) > 0:
+                            loss += loss_func(afn_pred, y.squeeze(), reduction='sum')
+                        if self.use_dnn:
+                            loss += loss_func(dnn_pred, y.squeeze(), reduction='sum')
+                        reg_loss = self.get_regularization_loss()
+
+                        total_loss = loss + reg_loss + self.aux_loss
+
+                        loss_epoch += loss.item()
+                        total_loss_epoch += total_loss.item()
+                        total_loss.backward()
+                        optim.step()
+
+                        if verbose > 0:
+                            for name, metric_fun in self.metrics.items():
+                                if name not in train_result:
+                                    train_result[name] = []
+                                train_result[name].append(metric_fun(
+                                    y.cpu().data.numpy(), y_pred.cpu().data.numpy().astype("float64")))
+
+
+            except KeyboardInterrupt:
+                t.close()
+                raise
+            t.close()
+
+            # Add epoch_logs
+            epoch_logs["loss"] = total_loss_epoch / sample_num
+            for name, result in train_result.items():
+                epoch_logs[name] = np.sum(result) / steps_per_epoch
+
+            if do_validation:
+                eval_result = self.evaluate(val_x, val_y, batch_size)
+                for name, result in eval_result.items():
+                    epoch_logs["val_" + name] = result
+            # verbose
+            if verbose > 0:
+                epoch_time = int(time.time() - start_time)
+                print('Epoch {0}/{1}'.format(epoch + 1, epochs))
+
+                eval_str = "{0}s - loss: {1: .4f}".format(
+                    epoch_time, epoch_logs["loss"])
+
+                for name in self.metrics:
+                    eval_str += " - " + name + \
+                                ": {0: .4f}".format(epoch_logs[name])
+
+                if do_validation:
+                    for name in self.metrics:
+                        eval_str += " - " + "val_" + name + \
+                                    ": {0: .4f}".format(epoch_logs["val_" + name])
+                print(eval_str)
+            callbacks.on_epoch_end(epoch, epoch_logs)
+            if self.stop_training:
+                break
+
+        callbacks.on_train_end()
+
+        return self.history
+
+    def predict(self, x, batch_size=256):
+        """
+
+        :param x: The input data, as a Numpy array (or list of Numpy arrays if the model has multiple inputs).
+        :param batch_size: Integer. If unspecified, it will default to 256.
+        :return: Numpy array(s) of predictions.
+        """
+        model = self.eval()
+        if isinstance(x, dict):
+            x = [x[feature] for feature in self.feature_index]
+        for i in range(len(x)):
+            if len(x[i].shape) == 1:
+                x[i] = np.expand_dims(x[i], axis=1)
+
+        tensor_data = Data.TensorDataset(
+            torch.from_numpy(np.concatenate(x, axis=-1)))
+        test_loader = DataLoader(
+            dataset=tensor_data, shuffle=False, batch_size=batch_size)
+
+        pred_ans = []
+        with torch.no_grad():
+            for _, x_test in enumerate(test_loader):
+                x = x_test[0].to(self.device).float()
+                # Only use the ensembled output for prediction.
+                y_pred = model(x)[0].cpu().data.numpy()
+                pred_ans.append(y_pred)
+
+        return np.concatenate(pred_ans).astype("float64")

--- a/tests/models/AFN_test.py
+++ b/tests/models/AFN_test.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from deepctr_torch.callbacks import EarlyStopping, ModelCheckpoint
+from deepctr_torch.models import AFN
+from tests.utils import get_test_data, SAMPLE_SIZE, check_model, get_device
+
+
+@pytest.mark.parametrize(
+    'dnn_hidden_units, sparse_feature_num, dense_feature_num',
+    [((256, 128), 3, 0), 
+    ((256, 128), 3, 3),
+     ((256, 128), 0,3),
+     ((), 3,0),
+     ((), 3,3),
+     ((), 0,0)]
+)
+
+def test_AFN(dnn_hidden_units, sparse_feature_num, dense_feature_num):
+    model_name = 'AFN'
+    sample_size = SAMPLE_SIZE
+    x, y, feature_columns = get_test_data(
+        sample_size, sparse_feature_num=sparse_feature_num, dense_feature_num=dense_feature_num)
+
+    model = AFN(linear_feature_columns=feature_columns, dnn_feature_columns=feature_columns,
+                dnn_hidden_units=dnn_hidden_units, device=get_device())
+
+    check_model(model, model_name, x, y)
+
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
调整了代码结构，增加了测试文件。

注：afn.py中没有直接继承基类的fit和predict，是为了兼容ensemble training时的多个输出分别计算loss；但是相比基类改动其实只替换了几行：234\~244，326\~330，后续维护应该不会很麻烦（如果不这样做无法实现论文中的ensemble training）