### PR TITLE
修复basemodel中对training/validation划分的逻辑问题，严重！

### DIFF
--- a/deepctr_torch/models/basemodel.py
+++ b/deepctr_torch/models/basemodel.py
@@ -26,7 +26,7 @@ except ImportError:
 from ..inputs import build_input_features, SparseFeat, DenseFeat, VarLenSparseFeat, get_varlen_pooling_list, \
     create_embedding_matrix, varlen_embedding_lookup
 from ..layers import PredictionLayer
-from ..layers.utils import slice_arrays
+# from ..layers.utils import slice_arrays
 from ..callbacks import History
 
 
@@ -133,7 +133,7 @@ class BaseModel(nn.Module):
         self._ckpt_saved_epoch = False  # used for EarlyStopping in tf1.14
         self.history = History()
 
-    def fit(self, x=None, y=None, batch_size=None, epochs=1, verbose=1, initial_epoch=0, validation_split=0.,
+    def fit(self, x=None, y=None, batch_size=256, epochs=1, verbose=1, initial_epoch=0, validation_split=0.,
             validation_data=None, shuffle=True, callbacks=None):
         """
 
@@ -153,6 +153,20 @@ class BaseModel(nn.Module):
         """
         if isinstance(x, dict):
             x = [x[feature] for feature in self.feature_index]
+
+        for i in range(len(x)):
+            if len(x[i].shape) == 1:
+                x[i] = np.expand_dims(x[i], axis=1)
+
+        if len(y.shape) == 1:
+            y_2d = np.expand_dims(y, axis=1)
+
+        x_y = np.concatenate(x + [y_2d], axis=-1)
+        if shuffle:
+            # shuffle operation should be prior to the seperation of training set and validation set.
+            np.random.shuffle(x_y)  # The np.random.shuffle() is an inplace operation!
+        x = x_y[:, :-1]
+        y = x_y[:, -1]
 
         do_validation = False
         if validation_data:
@@ -175,28 +189,17 @@ class BaseModel(nn.Module):
 
         elif validation_split and 0. < validation_split < 1.:
             do_validation = True
-            if hasattr(x[0], 'shape'):
-                split_at = int(x[0].shape[0] * (1. - validation_split))
-            else:
-                split_at = int(len(x[0]) * (1. - validation_split))
-            x, val_x = (slice_arrays(x, 0, split_at),
-                        slice_arrays(x, split_at))
-            y, val_y = (slice_arrays(y, 0, split_at),
-                        slice_arrays(y, split_at))
 
+            # x is a 2d numpy array. slice_arrays in utils.py can be removed.
+            split_at = int(len(x) * (1. - validation_split))
+            x, val_x = x[:split_at], x[split_at:]
+            y, val_y = y[:split_at], y[split_at:]
         else:
             val_x = []
             val_y = []
-        for i in range(len(x)):
-            if len(x[i].shape) == 1:
-                x[i] = np.expand_dims(x[i], axis=1)
 
-        train_tensor_data = Data.TensorDataset(
-            torch.from_numpy(
-                np.concatenate(x, axis=-1)),
-            torch.from_numpy(y))
-        if batch_size is None:
-            batch_size = 256
+        train_tensor_data = Data.TensorDataset(torch.from_numpy(x),
+                                               torch.from_numpy(y))
 
         model = self.train()
         loss_func = self.loss_func
@@ -229,6 +232,7 @@ class BaseModel(nn.Module):
         print("Train on {0} samples, validate on {1} samples, {2} steps per epoch".format(
             len(train_tensor_data), len(val_y), steps_per_epoch))
         for epoch in range(initial_epoch, epochs):
+            print("Training the {}/{} epoch".format(epoch, epochs))
             callbacks.on_epoch_begin(epoch)
             epoch_logs = {}
             start_time = time.time()
@@ -236,7 +240,7 @@ class BaseModel(nn.Module):
             total_loss_epoch = 0
             train_result = {}
             try:
-                with tqdm(enumerate(train_loader), disable=verbose != 1) as t:
+                with tqdm(enumerate(train_loader), disable=verbose != 1, total=steps_per_epoch) as t:
                     for _, (x_train, y_train) in t:
                         x = x_train.to(self.device).float()
                         y = y_train.to(self.device).float()
@@ -315,7 +319,7 @@ class BaseModel(nn.Module):
             eval_result[name] = metric_fun(y, pred_ans)
         return eval_result
 
-    def predict(self, x, batch_size=256):
+    def predict(self, x, batch_size=256, verbose=False):
         """
 
         :param x: The input data, as a Numpy array (or list of Numpy arrays if the model has multiple inputs).
@@ -323,20 +327,32 @@ class BaseModel(nn.Module):
         :return: Numpy array(s) of predictions.
         """
         model = self.eval()
-        if isinstance(x, dict):
-            x = [x[feature] for feature in self.feature_index]
-        for i in range(len(x)):
-            if len(x[i].shape) == 1:
-                x[i] = np.expand_dims(x[i], axis=1)
 
-        tensor_data = Data.TensorDataset(
-            torch.from_numpy(np.concatenate(x, axis=-1)))
+        if isinstance(x, dict):
+            # x is the origial dict with values being 1-dim numpy array (Sparse feature)
+            # or multiple-dim numpy array (Varlen sequence, or multi-dim dense features)
+            x = [x[feature] for feature in self.feature_index]
+
+            for i in range(len(x)):
+                if len(x[i].shape) == 1:
+                    x[i] = np.expand_dims(x[i], axis=1)
+            tensor_data = Data.TensorDataset(
+                torch.from_numpy(np.concatenate(x, axis=-1)))
+        else:
+            # x is already in numpy array
+            tensor_data = Data.TensorDataset(torch.from_numpy(x))
+
         test_loader = DataLoader(
             dataset=tensor_data, shuffle=False, batch_size=batch_size)
 
+        sample_num = len(tensor_data)
+        steps_per_epoch = (sample_num - 1) // batch_size + 1
+
         pred_ans = []
         with torch.no_grad():
-            for _, x_test in enumerate(test_loader):
+            # for _, x_test in enumerate(test_loader):
+            for _, x_test in tqdm(enumerate(test_loader), disable=verbose != 1, total=steps_per_epoch,
+                                  desc="Predicting data..."):
                 x = x_test[0].to(self.device).float()
 
                 y_pred = model(x).cpu().data.numpy()  # .squeeze()

--- a/tests/models/DIEN_test.py
+++ b/tests/models/DIEN_test.py
@@ -93,7 +93,8 @@ def test_DIEN(gru_type, use_neg):
     model = DIEN(feature_columns, behavior_feature_list, gru_type=gru_type, use_negsampling=use_neg,
                  dnn_hidden_units=[4, 4, 4], dnn_dropout=0.5, device=get_device())
 
-    check_model(model, model_name, x, y)
+    check_model(model, model_name, x, y, shuffle=False)
+    # There are only 4 instances in the dataset, so shuffle should be false, in case that: (y = (1,1) and val_y = (0,0)) after shuffling.
 
 
 if __name__ == "__main__":

--- a/tests/models/DIN_test.py
+++ b/tests/models/DIN_test.py
@@ -47,7 +47,9 @@ def test_DIN():
     x, y, feature_columns, behavior_feature_list = get_xy_fd()
     model = DIN(feature_columns, behavior_feature_list, dnn_dropout=0.5, device=get_device())
 
-    check_model(model, model_name, x, y)  # only have 3 train data so we set validation ratio at 0
+    check_model(model, model_name, x, y, shuffle=False)
+    # There are only 4 instances in the dataset, so shuffle should be false, in case that: (y = (1,1) and val_y = (0,0)) after shuffling.
+
 
 
 if __name__ == "__main__":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -138,7 +138,7 @@ def layer_test(layer_cls, kwargs = {}, input_shape=None,
     return output
 
 
-def check_model(model, model_name, x, y, check_model_io=True):
+def check_model(model, model_name, x, y, check_model_io=True, shuffle=True):
     '''
     compile model,train and evaluate it,then save/load weight and model file.
     :param model:
@@ -146,12 +146,13 @@ def check_model(model, model_name, x, y, check_model_io=True):
     :param x:
     :param y:
     :param check_model_io:
+    :param shuffle: pass to the basemodel.fit
     :return:
     '''
 
     model.compile('adam', 'binary_crossentropy',
                   metrics=['binary_crossentropy'])
-    model.fit(x, y, batch_size=100, epochs=1, validation_split=0.5)
+    model.fit(x, y, batch_size=100, epochs=1, validation_split=0.5, shuffle=shuffle)
 
     print(model_name + 'test, train valid pass!')
     torch.save(model.state_dict(), model_name + '_weights.h5')


### PR DESCRIPTION
#### 1. 目前basemodel逻辑的比较严重的问题

`basemodel.py`在划分training set和validation set时候逻辑有问题。

举个例子：

如果划分training data和validation data比例为80%：20%。

而原始的data的label为：

```
y = [0] * 90 + [1] * 10 # 即所有正样本都在y的尾部。
```

那么basemodel的以下代码

```
y_train, y_val = (slice_arrays(y, 0, 80), slice_arrays(y, 80))
```

将会把80个0放到`y_train`中，把剩下10个0和10个1放到`y_val`中。即`y_train`全为负样本0，所有正样本全在`y_val`中。

以上的例子只是一个比较极端的例子。总而言之，当默认shuffle=True时候，**划分training和validation应该是随机的，不应该依赖数据的位置！**

*注意：这时候即便选择basemodel的shuffle参数等于True，还是不能得到正确的划分。因为shuffle参数只影响dataloader，没有作用在training和validation的划分上。*

#### 2. 本次pull request修复的逻辑：

1. 在basemodel.fit中，不同于之前的先划分数据、再转为numpy array，我将逻辑调整为先转为numpy array，再切分数据。由于数据先转为numpy，也避免了util.slice_arrays函数的复杂逻辑。

2. 略微调整了下tqdm的进度条，加了一个total参数，让进度条有个终点。
3. 调整basemodel.predict函数，使得顺应改动。
4. 调整tests/models/DIN_test.py 与 tests/models/DIEN_test.py两个test逻辑。由于这两个test只有4个样本输入，故在shuffle后很容易将正负样本分开置于training、validation中。故这里不能shuffle，故调整了test的代码。使得所有test都能顺利通过。