### PR TITLE
Update basemodel.py and fix the logic

### DIFF
--- a/tests/models/DIEN_test.py
+++ b/tests/models/DIEN_test.py
@@ -93,7 +93,8 @@ def test_DIEN(gru_type, use_neg):
     model = DIEN(feature_columns, behavior_feature_list, gru_type=gru_type, use_negsampling=use_neg,
                  dnn_hidden_units=[4, 4, 4], dnn_dropout=0.5, device=get_device())
 
-    check_model(model, model_name, x, y)
+    check_model(model, model_name, x, y, shuffle=False)
+    # There are only 4 instances in the dataset, so shuffle should be false, in case that: (y = (1,1) and val_y = (0,0)) after shuffling.
 
 
 if __name__ == "__main__":

--- a/tests/models/DIN_test.py
+++ b/tests/models/DIN_test.py
@@ -47,7 +47,9 @@ def test_DIN():
     x, y, feature_columns, behavior_feature_list = get_xy_fd()
     model = DIN(feature_columns, behavior_feature_list, dnn_dropout=0.5, device=get_device())
 
-    check_model(model, model_name, x, y)  # only have 3 train data so we set validation ratio at 0
+    check_model(model, model_name, x, y, shuffle=False)
+    # There are only 4 instances in the dataset, so shuffle should be false, in case that: (y = (1,1) and val_y = (0,0)) after shuffling.
+
 
 
 if __name__ == "__main__":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -138,7 +138,7 @@ def layer_test(layer_cls, kwargs = {}, input_shape=None,
     return output
 
 
-def check_model(model, model_name, x, y, check_model_io=True):
+def check_model(model, model_name, x, y, check_model_io=True, shuffle=True):
     '''
     compile model,train and evaluate it,then save/load weight and model file.
     :param model:
@@ -146,12 +146,13 @@ def check_model(model, model_name, x, y, check_model_io=True):
     :param x:
     :param y:
     :param check_model_io:
+    :param shuffle: pass to the basemodel.fit
     :return:
     '''
 
     model.compile('adam', 'binary_crossentropy',
                   metrics=['binary_crossentropy'])
-    model.fit(x, y, batch_size=100, epochs=1, validation_split=0.5)
+    model.fit(x, y, batch_size=100, epochs=1, validation_split=0.5, shuffle=shuffle)
 
     print(model_name + 'test, train valid pass!')
     torch.save(model.state_dict(), model_name + '_weights.h5')


### PR DESCRIPTION
### 修复basemodel中training data和validation data划分问题

#### 1. 目前basemodel中比较严重的逻辑问题

`basemodel.py`在划分training set和validation set时候逻辑有问题。

举个例子：

如果划分training data和validation data比例为80%：20%。

而原始的data的label为：

```
y = [0] * 90 + [1] * 10 # 即所有正样本都在y的尾部。
```

那么basemodel的以下代码

```
y_train, y_val = (slice_arrays(y, 0, 80), slice_arrays(y, 80))
```

将会把80个0放到`y_train`中，把剩下10个0和10个1放到`y_val`中。即`y_train`全为负样本0，所有正样本全在`y_val`中。

以上的例子只是一个比较极端的例子。总而言之，当默认shuffle=True时候，**划分training和validation应该是随机的，不应该依赖数据的位置！**

*注意：这时候即便选择basemodel的shuffle参数等于True，还是不能得到正确的划分。因为shuffle参数只影响dataloader，没有作用在training和validation的划分上。*


#### 2. 本次pull request修复的逻辑：

1. 在basemodel.fit中，不同于之前的先划分数据、再转为numpy array，我将逻辑调整为先转为numpy array，再切分数据。由于数据先转为numpy，也避免了util.slice_arrays函数的复杂逻辑。

2. 略微调整了下tqdm的进度条，加了一个total参数，让进度条有个终点。
3. 调整basemodel.predict函数，使得顺应改动。
4. 调整tests/models/DIN_test.py 与 tests/models/DIEN_test.py两个test逻辑。由于这两个test只有4个样本输入，故在shuffle后很容易将正负样本分开置于training、validation中。故这里不能shuffle，故调整了test的代码。使得所有test都能顺利通过。