### PR TITLE
fix bug #106: model save issue

### DIFF
--- a/deepctr_torch/models/basemodel.py
+++ b/deepctr_torch/models/basemodel.py
@@ -476,6 +476,9 @@ class BaseModel(nn.Module):
                         sample_weight,
                         labels)
 
+    def _accuracy_score(self, y_true, y_pred):
+        return accuracy_score(y_true, np.where(y_pred > 0.5, 1, 0))
+
     def _get_metrics(self, metrics, set_eps=False):
         metrics_ = {}
         if metrics:
@@ -490,8 +493,7 @@ class BaseModel(nn.Module):
                 if metric == "mse":
                     metrics_[metric] = mean_squared_error
                 if metric == "accuracy" or metric == "acc":
-                    metrics_[metric] = lambda y_true, y_pred: accuracy_score(
-                        y_true, np.where(y_pred > 0.5, 1, 0))
+                    metrics_[metric] = self._accuracy_score
                 self.metrics_names.append(metric)
         return metrics_
 


### PR DESCRIPTION
解决了 #106  无法保存模型的bug。

原因是lambda表达式无法被pickled。

在`basemodel.py`中的`accuracy`使用了lambda表达式
https://github.com/shenweichen/DeepCTR-Torch/blob/b4d8181e86c2165722fa9331bc16185832596232/deepctr_torch/models/basemodel.py#L492-L494

https://github.com/shenweichen/DeepCTR-Torch/issues/106#issuecomment-862417549 给出了复现方法