### PR TITLE
fix #106: model save issue

### DIFF
--- a/deepctr_torch/models/basemodel.py
+++ b/deepctr_torch/models/basemodel.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.data as Data
 from sklearn.metrics import *
+from sklearn.metrics import accuracy_score
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -476,7 +477,8 @@ class BaseModel(nn.Module):
                         sample_weight,
                         labels)
 
-    def _accuracy_score(self, y_true, y_pred):
+    @staticmethod
+    def _accuracy_score(y_true, y_pred):
         return accuracy_score(y_true, np.where(y_pred > 0.5, 1, 0))
 
     def _get_metrics(self, metrics, set_eps=False):

--- a/deepctr_torch/models/basemodel.py
+++ b/deepctr_torch/models/basemodel.py
@@ -475,6 +475,9 @@ class BaseModel(nn.Module):
                         normalize,
                         sample_weight,
                         labels)
+    
+    def _accuracy_score(self, y_true, y_pred):
+        return accuracy_score(y_true, np.where(y_pred > 0.5, 1, 0))
 
     def _get_metrics(self, metrics, set_eps=False):
         metrics_ = {}
@@ -490,8 +493,7 @@ class BaseModel(nn.Module):
                 if metric == "mse":
                     metrics_[metric] = mean_squared_error
                 if metric == "accuracy" or metric == "acc":
-                    metrics_[metric] = lambda y_true, y_pred: accuracy_score(
-                        y_true, np.where(y_pred > 0.5, 1, 0))
+                    metrics_[metric] = self._accuracy_score
                 self.metrics_names.append(metric)
         return metrics_
 

--- a/deepctr_torch/models/basemodel.py
+++ b/deepctr_torch/models/basemodel.py
@@ -475,7 +475,7 @@ class BaseModel(nn.Module):
                         normalize,
                         sample_weight,
                         labels)
-    
+
     def _accuracy_score(self, y_true, y_pred):
         return accuracy_score(y_true, np.where(y_pred > 0.5, 1, 0))
 

--- a/tests/savemodel_with_acc_test.py
+++ b/tests/savemodel_with_acc_test.py
@@ -1,0 +1,34 @@
+"""
+Date: 2021-07-13 11:59:44
+LastEditors: GodK
+LastEditTime: 2021-07-13 12:26:11
+"""
+import pytest
+from deepctr_torch.models import DeepFM
+from deepctr_torch.callbacks import EarlyStopping, ModelCheckpoint
+from .utils import get_test_data, SAMPLE_SIZE,get_device
+
+@pytest.mark.parametrize(
+    'use_fm,hidden_size,sparse_feature_num',
+    [(True, (32,), 3),
+     (False, (32,), 3),
+     (False, (32,), 2), (False, (32,), 1), (True, (), 1), (False, (), 2)
+     ]
+)
+def test_save(use_fm, hidden_size, sparse_feature_num):
+    sample_size = SAMPLE_SIZE
+    x, y, feature_columns = get_test_data(
+        sample_size, sparse_feature_num=sparse_feature_num, dense_feature_num=sparse_feature_num)
+    model = DeepFM(feature_columns, feature_columns, use_fm=use_fm,
+                   dnn_hidden_units=hidden_size, dnn_dropout=0.5, device=get_device())
+    
+    # test callbacks
+    early_stopping = EarlyStopping(monitor='val_acc', min_delta=0, verbose=1, patience=0, mode='max')
+    model_checkpoint = ModelCheckpoint(filepath='model.ckpt', monitor='val_acc', verbose=1,
+                                       save_best_only=True,
+                                       save_weights_only=False, mode='max', period=1)
+    model.compile('adam', 'binary_crossentropy', metrics=['binary_crossentropy','acc'])
+    model.fit(x, y, batch_size=64, epochs=3, validation_split=0.5, callbacks=[early_stopping, model_checkpoint])
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
解决了 #106  无法保存模型的bug。

原因是lambda表达式无法被pickled。

在`basemodel.py`中的`accuracy`使用了lambda表达式
https://github.com/shenweichen/DeepCTR-Torch/blob/b4d8181e86c2165722fa9331bc16185832596232/deepctr_torch/models/basemodel.py#L492-L494

https://github.com/shenweichen/DeepCTR-Torch/issues/106#issuecomment-862417549 给出了复现方法