### PR TITLE
fix `Tensors must have same number of dimensions: got 1 and 2` in Cro…

### DIFF
--- a/deepctr_torch/layers/interaction.py
+++ b/deepctr_torch/layers/interaction.py
@@ -530,7 +530,7 @@ class CrossNetMix(nn.Module):
             moe_out = torch.matmul(output_of_experts, gating_score_of_experts.softmax(1))
             x_l = moe_out + x_l  # (bs, in_features, 1)
 
-        x_l = x_l.squeeze()  # (bs, in_features)
+        x_l = torch.squeeze(x_l, dim=2)  # (bs, in_features)
         return x_l
 
 


### PR DESCRIPTION
Fix the error "Tensors must have the same number of dimensions: got 1 and 2" in CrossNetMix. The function `torch.squeeze(x_l)` generates a one-dimensional vector.