### PR TITLE
Consistent verbose behavior

### DIFF
--- a/deepctr_torch/models/basemodel.py
+++ b/deepctr_torch/models/basemodel.py
@@ -47,11 +47,6 @@ class Linear(nn.Module):
         self.embedding_dict = create_embedding_matrix(feature_columns, init_std, linear=True, sparse=False,
                                                       device=device)
 
-        #         nn.ModuleDict(
-        #             {feat.embedding_name: nn.Embedding(feat.dimension, 1, sparse=True) for feat in
-        #              self.sparse_feature_columns}
-        #         )
-        # .to("cuda:1")
         for tensor in self.embedding_dict.values():
             nn.init.normal_(tensor.weight, mean=0, std=init_std)
 
@@ -227,8 +222,9 @@ class BaseModel(nn.Module):
         callbacks.model.stop_training = False
 
         # Train
-        print("Train on {0} samples, validate on {1} samples, {2} steps per epoch".format(
-            len(train_tensor_data), len(val_y), steps_per_epoch))
+        if verbose > 0:
+            print("Train on {0} samples, validate on {1} samples, {2} steps per epoch".format(
+                len(train_tensor_data), len(val_y), steps_per_epoch))
         for epoch in range(initial_epoch, epochs):
             callbacks.on_epoch_begin(epoch)
             epoch_logs = {}


### PR DESCRIPTION
Currently, there remain logs even if `verbose=0`. This is undesired behavior. - moved the troublesome log to `verbose > 0` scope.