### PR TITLE
Align InteractingLayer initialization with DeepCTR

### DIFF
--- a/deepctr_torch/layers/interaction.py
+++ b/deepctr_torch/layers/interaction.py
@@ -372,8 +372,8 @@ class InteractingLayer(nn.Module):
         if self.use_res:
             self.W_Res = nn.Parameter(torch.Tensor(embedding_size, output_size))
         for tensor in self.parameters():
-            nn.init.trunc_normal_(tensor, mean=0.0, std=0.05,
-                                  a=-0.1, b=0.1)
+            nn.init.trunc_normal_(tensor, mean=0.0, std=1.0,
+                                  a=-2.0, b=2.0)
 
         self.to(device)
 

--- a/tests/layers/interaction_test.py
+++ b/tests/layers/interaction_test.py
@@ -76,7 +76,8 @@ def test_other_interaction_layers_match_tf():
 
     layer = InteractingLayer(embedding_size=8, head_num=2, use_res=True)
     for parameter in layer.parameters():
-        assert torch.max(torch.abs(parameter)) <= 0.1
+        assert torch.max(torch.abs(parameter)) <= 2.0
+        assert parameter.std() > 0.1
 
     layer = InteractingLayer(
         embedding_size=6, head_num=2, att_embedding_size=4, use_res=True)


### PR DESCRIPTION
## Summary
- Align `InteractingLayer` truncated-normal initialization with DeepCTR/TensorFlow's default `TruncatedNormal` scale.
- Update the layer test expectation for the wider truncated-normal range.

## Validation
- `python -m pytest tests/layers/interaction_test.py tests/models/AutoInt_test.py tests/models/DIFM_test.py -q`
- Criteo2M GPU spot checks, 1 epoch, batch size 1024, seeds 2026/2027/2028:
  - AutoInt TF-vs-Torch mean AUC gap narrowed from `+0.001531` to `+0.000586`.
  - AutoInt Torch mean AUC changed from `0.786146` to `0.787090`.
  - DIFM new branch vs master mean AUC changed by `+0.000598`.